### PR TITLE
Refactor ECR login to use get-login-password (#15)

### DIFF
--- a/images/base/kdp-datainput-base/Makefile
+++ b/images/base/kdp-datainput-base/Makefile
@@ -77,14 +77,17 @@ endif
 # HELPERS
 
 # generate script to login to aws docker repo
-CMD_REPOLOGIN := "eval $$\( aws ecr"
+CMD_REPOLOGIN := "aws ecr get-login-password"
 ifdef AWS_CLI_PROFILE
 CMD_REPOLOGIN += " --profile $(AWS_CLI_PROFILE)"
 endif
 ifdef AWS_CLI_REGION
 CMD_REPOLOGIN += " --region $(AWS_CLI_REGION)"
 endif
-CMD_REPOLOGIN += " get-login --no-include-email \)"
+CMD_REPOLOGIN += " | docker login --username AWS --password-stdin"
+ifdef DOCKER_REPO
+CMD_REPOLOGIN += " $(DOCKER_REPO)"
+endif
 
 # login to AWS-ECR
 aws-login: ## Auto login to AWS-ECR using aws-cli

--- a/images/base/kdp-node-base/Makefile
+++ b/images/base/kdp-node-base/Makefile
@@ -79,14 +79,17 @@ endif
 # HELPERS
 
 # generate script to login to aws docker repo
-CMD_REPOLOGIN := "eval $$\( aws ecr"
+CMD_REPOLOGIN := "aws ecr get-login-password"
 ifdef AWS_CLI_PROFILE
 CMD_REPOLOGIN += " --profile $(AWS_CLI_PROFILE)"
 endif
 ifdef AWS_CLI_REGION
 CMD_REPOLOGIN += " --region $(AWS_CLI_REGION)"
 endif
-CMD_REPOLOGIN += " get-login --no-include-email \)"
+CMD_REPOLOGIN += " | docker login --username AWS --password-stdin"
+ifdef DOCKER_REPO
+CMD_REPOLOGIN += " $(DOCKER_REPO)"
+endif
 
 # login to AWS-ECR
 aws-login: ## Auto login to AWS-ECR using aws-cli

--- a/images/examples/datainputs/kdp-datainput-prefix-listing/Makefile
+++ b/images/examples/datainputs/kdp-datainput-prefix-listing/Makefile
@@ -77,14 +77,17 @@ endif
 # HELPERS
 
 # generate script to login to aws docker repo
-CMD_REPOLOGIN := "eval $$\( aws ecr"
+CMD_REPOLOGIN := "aws ecr get-login-password"
 ifdef AWS_CLI_PROFILE
 CMD_REPOLOGIN += " --profile $(AWS_CLI_PROFILE)"
 endif
 ifdef AWS_CLI_REGION
 CMD_REPOLOGIN += " --region $(AWS_CLI_REGION)"
 endif
-CMD_REPOLOGIN += " get-login --no-include-email \)"
+CMD_REPOLOGIN += " | docker login --username AWS --password-stdin"
+ifdef DOCKER_REPO
+CMD_REPOLOGIN += " $(DOCKER_REPO)"
+endif
 
 # login to AWS-ECR
 aws-login: ## Auto login to AWS-ECR using aws-cli

--- a/images/examples/datainputs/kdp-datainput-singleinput/Makefile
+++ b/images/examples/datainputs/kdp-datainput-singleinput/Makefile
@@ -77,14 +77,17 @@ endif
 # HELPERS
 
 # generate script to login to aws docker repo
-CMD_REPOLOGIN := "eval $$\( aws ecr"
+CMD_REPOLOGIN := "aws ecr get-login-password"
 ifdef AWS_CLI_PROFILE
 CMD_REPOLOGIN += " --profile $(AWS_CLI_PROFILE)"
 endif
 ifdef AWS_CLI_REGION
 CMD_REPOLOGIN += " --region $(AWS_CLI_REGION)"
 endif
-CMD_REPOLOGIN += " get-login --no-include-email \)"
+CMD_REPOLOGIN += " | docker login --username AWS --password-stdin"
+ifdef DOCKER_REPO
+CMD_REPOLOGIN += " $(DOCKER_REPO)"
+endif
 
 # login to AWS-ECR
 aws-login: ## Auto login to AWS-ECR using aws-cli

--- a/images/examples/nodes/kdp-node-passthrough/Makefile
+++ b/images/examples/nodes/kdp-node-passthrough/Makefile
@@ -77,14 +77,17 @@ endif
 # HELPERS
 
 # generate script to login to aws docker repo
-CMD_REPOLOGIN := "eval $$\( aws ecr"
+CMD_REPOLOGIN := "aws ecr get-login-password"
 ifdef AWS_CLI_PROFILE
 CMD_REPOLOGIN += " --profile $(AWS_CLI_PROFILE)"
 endif
 ifdef AWS_CLI_REGION
 CMD_REPOLOGIN += " --region $(AWS_CLI_REGION)"
 endif
-CMD_REPOLOGIN += " get-login --no-include-email \)"
+CMD_REPOLOGIN += " | docker login --username AWS --password-stdin"
+ifdef DOCKER_REPO
+CMD_REPOLOGIN += " $(DOCKER_REPO)"
+endif
 
 # login to AWS-ECR
 aws-login: ## Auto login to AWS-ECR using aws-cli

--- a/images/examples/nodes/kdp-node-validate-directory/Makefile
+++ b/images/examples/nodes/kdp-node-validate-directory/Makefile
@@ -77,14 +77,17 @@ endif
 # HELPERS
 
 # generate script to login to aws docker repo
-CMD_REPOLOGIN := "eval $$\( aws ecr"
+CMD_REPOLOGIN := "aws ecr get-login-password"
 ifdef AWS_CLI_PROFILE
 CMD_REPOLOGIN += " --profile $(AWS_CLI_PROFILE)"
 endif
 ifdef AWS_CLI_REGION
 CMD_REPOLOGIN += " --region $(AWS_CLI_REGION)"
 endif
-CMD_REPOLOGIN += " get-login --no-include-email \)"
+CMD_REPOLOGIN += " | docker login --username AWS --password-stdin"
+ifdef DOCKER_REPO
+CMD_REPOLOGIN += " $(DOCKER_REPO)"
+endif
 
 # login to AWS-ECR
 aws-login: ## Auto login to AWS-ECR using aws-cli

--- a/images/examples/nodes/kdp-node-validate/Makefile
+++ b/images/examples/nodes/kdp-node-validate/Makefile
@@ -77,14 +77,17 @@ endif
 # HELPERS
 
 # generate script to login to aws docker repo
-CMD_REPOLOGIN := "eval $$\( aws ecr"
+CMD_REPOLOGIN := "aws ecr get-login-password"
 ifdef AWS_CLI_PROFILE
 CMD_REPOLOGIN += " --profile $(AWS_CLI_PROFILE)"
 endif
 ifdef AWS_CLI_REGION
 CMD_REPOLOGIN += " --region $(AWS_CLI_REGION)"
 endif
-CMD_REPOLOGIN += " get-login --no-include-email \)"
+CMD_REPOLOGIN += " | docker login --username AWS --password-stdin"
+ifdef DOCKER_REPO
+CMD_REPOLOGIN += " $(DOCKER_REPO)"
+endif
 
 # login to AWS-ECR
 aws-login: ## Auto login to AWS-ECR using aws-cli

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -78,14 +78,17 @@ endif
 # HELPERS
 
 # generate script to login to aws docker repo
-CMD_REPOLOGIN := "eval $$\( aws ecr"
+CMD_REPOLOGIN := "aws ecr get-login-password"
 ifdef AWS_CLI_PROFILE
 CMD_REPOLOGIN += " --profile $(AWS_CLI_PROFILE)"
 endif
 ifdef AWS_CLI_REGION
 CMD_REPOLOGIN += " --region $(AWS_CLI_REGION)"
 endif
-CMD_REPOLOGIN += " get-login --no-include-email \)"
+CMD_REPOLOGIN += " | docker login --username AWS --password-stdin"
+ifdef DOCKER_REPO
+CMD_REPOLOGIN += " $(DOCKER_REPO)"
+endif
 
 # login to AWS-ECR
 aws-login: ## Auto login to AWS-ECR using aws-cli


### PR DESCRIPTION
**Tests**
```sh
$ make publish-all-aws DOCKER_REPO=XXXX.amazonaws.com AWS_CLI_REGION=XXXX AWS_CLI_PROFILE=XXXX
/Library/Developer/CommandLineTools/usr/bin/make -C ../operator  "DOCKER_REPO=\"XXXX.amazonaws.com\"" " AWS_CLI_PROFILE=\"XXX\"" " AWS_CLI_REGION=\"XXXX\"" publish-aws
Login Succeeded
# ...etc etc...
```

**Related Issues**
<!--
    Reference related issues here. For more information: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
->
Resolves #15.